### PR TITLE
feat(zhipu_toolkit): 优化聊天管理并添加封禁工具

### DIFF
--- a/zhipu_toolkit/__init__.py
+++ b/zhipu_toolkit/__init__.py
@@ -110,6 +110,12 @@ __plugin_meta__ = PluginMetadata(
                 default_value=False,
             ),
             RegisterConfig(
+                key="EXPIRE_DAY",
+                value=3,
+                help="用户对话记录保存时间(天), -1表示永久保存",
+                default_value=3,
+            ),
+            RegisterConfig(
                 key="SOUL",
                 value=None,
                 help="已弃用",

--- a/zhipu_toolkit/__init__.py
+++ b/zhipu_toolkit/__init__.py
@@ -32,7 +32,7 @@ __plugin_meta__ = PluginMetadata(
     """.strip(),
     extra=PluginExtraData(
         author="molanp",
-        version="1.6",
+        version="1.7",
         menu_type="群内小游戏",
         superuser_help="""
         超级管理员额外命令

--- a/zhipu_toolkit/__init__.py
+++ b/zhipu_toolkit/__init__.py
@@ -116,6 +116,12 @@ __plugin_meta__ = PluginMetadata(
                 default_value=3,
             ),
             RegisterConfig(
+                key="WORD_LIMIT",
+                value=500,
+                help="单次对话消息字数限制(最大值一般为4095)",
+                default_value=500,
+            ),
+            RegisterConfig(
                 key="SOUL",
                 value=None,
                 help="已弃用",

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -185,13 +185,14 @@ class ChatManager:
             uid,
         )
         message = await msg2str(msg)
-        if len(message) > 4095:
+        word_limit = ChatConfig.get("word_limit")
+        if len(message) > word_limit:
             logger.warning(
-                f"USER {uid} USERNAME {username} 问题: {message} ---- 超出最大token限制: 4095",  # noqa: E501
+                f"USER {uid} USERNAME {username} 问题: {message} ---- 超出字数限制: {word_limit}",  # noqa: E501
                 "zhipu_toolkit",
                 session=session,
             )
-            return "超出最大token限制: 4095"
+            return f"超出管理员设置的字数限制: {word_limit}"
         await cls.add_user_message(
             await format_usr_msg(username, session, message), uid
         )

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -297,7 +297,7 @@ class ChatManager:
         gid = session.scene.id
         try:
             if not (group_msg := GROUP_MSG_CACHE[gid]):
-            return
+                return
         except KeyError:
             return
 

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -2,9 +2,11 @@ import asyncio
 import datetime
 import os
 import random
-from typing import Any
-
 import aiofiles
+from typing import Any
+from nonebot import require
+require("nonebot_plugin_alconna")
+require("nonebot_plugin_uninfo")
 from nonebot_plugin_alconna import Text, UniMsg, Video
 from nonebot_plugin_uninfo import Session
 import ujson

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -70,7 +70,7 @@ async def cache_group_message(
             msg = GroupMessageModel(
                 uid=session.user.id,
                 username=await get_username_by_session(session),
-                msg=messge,
+                msg=message,
                 time=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             )
     

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -293,7 +293,10 @@ class ChatManager:
     @classmethod
     async def impersonation_result(cls, session: Session) -> str | None:
         gid = session.scene.id
-        if not (group_msg := GROUP_MSG_CACHE[gid]):
+        try:
+            if not (group_msg := GROUP_MSG_CACHE[gid]):
+            return
+        except KeyError:
             return
 
         CHAT_RECORDS = "".join(

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -211,12 +211,14 @@ class ChatManager:
             logger.error(
                 f"获取结果失败 e:{result.content}", "zhipu_toolkit", session=session
             )
+            await ZhipuChatHistory.delete_latest_record(uid)
             return f"出错了: {result.content}"
         if result.message is None:
             logger.error(
                 f"Missing result.message for uid: {uid}, returning error."
                 f"Result content: {result.content}"
             )
+            await ZhipuChatHistory.delete_latest_record(uid)
             return f"出错了: {result.content}"
         await cls.add_anytype_message(uid, result.message)
         tool_result = await cls.parse_function_call(

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -34,7 +34,7 @@ from .utils import (
 )
 
 GROUP_MSG_CACHE: dict[str, list[GroupMessageModel]] = {}
-
+_group_cache_lock = asyncio.Lock()
 
 async def cache_group_message(
     message: UniMsg, session: Session, self_name=None
@@ -54,35 +54,36 @@ async def cache_group_message(
     返回值:
     无返回值。
     """
-    msg = await msg2str(message)
-    if len(msg) > 255:
-        logger.warning("拒绝缓存此消息: 字数超限(255)", "zhipu_toolkit", session=session)
-        return
-    if self_name is not None:
-        msg = GroupMessageModel(
-            uid=session.self_id,
-            username=self_name,
-            msg=msg,
-            time=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-        )
-    else:
-        msg = GroupMessageModel(
-            uid=session.user.id,
-            username=await get_username_by_session(session),
-            msg=msg,
-            time=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-        )
-
-    gid = session.scene.id
-    logger.debug(f"GROUP {gid} 成功缓存聊天记录: {msg}", "zhipu_toolkit", session=session)
-    if gid in GROUP_MSG_CACHE:
-        if len(GROUP_MSG_CACHE[gid]) >= 20:
-            GROUP_MSG_CACHE[gid].pop(0)
-            logger.debug(f"GROUP {gid} 缓存已满，自动清理最早的记录", "zhipu_toolkit", session=session)
-
-        GROUP_MSG_CACHE[gid].append(msg)
-    else:
-        GROUP_MSG_CACHE[gid] = [msg]
+    async with _group_cache_lock:
+        message = await msg2str(message)
+        if len(message) > 255:
+            logger.warning("拒绝缓存此消息: 字数超限(255)", "zhipu_toolkit", session=session)
+            return
+        if self_name is not None:
+            msg = GroupMessageModel(
+                uid=session.self_id,
+                username=self_name,
+                msg=message,
+                time=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            )
+        else:
+            msg = GroupMessageModel(
+                uid=session.user.id,
+                username=await get_username_by_session(session),
+                msg=messge,
+                time=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            )
+    
+        gid = session.scene.id
+        logger.debug(f"GROUP {gid} 成功缓存聊天记录: {message}", "zhipu_toolkit", session=session)
+        if gid in GROUP_MSG_CACHE:
+            if len(GROUP_MSG_CACHE[gid]) >= 20:
+                GROUP_MSG_CACHE[gid].pop(0)
+                logger.debug(f"GROUP {gid} 缓存已满，自动清理最早的记录", "zhipu_toolkit", session=session)
+    
+            GROUP_MSG_CACHE[gid].append(msg)
+        else:
+            GROUP_MSG_CACHE[gid] = [msg]
 
 
 async def hello() -> list:

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -185,7 +185,7 @@ class ChatManager:
             uid,
         )
         message = await msg2str(msg)
-        word_limit = ChatConfig.get("word_limit")
+        word_limit = ChatConfig.get("WORD_LIMIT")
         if len(message) > word_limit:
             logger.warning(
                 f"USER {uid} USERNAME {username} 问题: {message} ---- 超出字数限制: {word_limit}",  # noqa: E501

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -56,7 +56,7 @@ async def cache_group_message(
     """
     msg = await msg2str(message)
     if len(msg) > 255:
-        logger.warning("拒绝缓存此消息: 字数超限(255)", "zhipu_toolkit")
+        logger.warning("拒绝缓存此消息: 字数超限(255)", "zhipu_toolkit", session=session)
         return
     if self_name is not None:
         msg = GroupMessageModel(
@@ -74,11 +74,11 @@ async def cache_group_message(
         )
 
     gid = session.scene.id
-    logger.debug(f"GROUP {gid} 成功缓存聊天记录: {msg}", "zhipu_toolkit")
+    logger.debug(f"GROUP {gid} 成功缓存聊天记录: {msg}", "zhipu_toolkit", session=session)
     if gid in GROUP_MSG_CACHE:
         if len(GROUP_MSG_CACHE[gid]) >= 20:
             GROUP_MSG_CACHE[gid].pop(0)
-            logger.debug(f"GROUP {gid} 缓存已满，自动清理最早的记录", "zhipu_toolkit")
+            logger.debug(f"GROUP {gid} 缓存已满，自动清理最早的记录", "zhipu_toolkit", session=session)
 
         GROUP_MSG_CACHE[gid].append(msg)
     else:

--- a/zhipu_toolkit/handler.py
+++ b/zhipu_toolkit/handler.py
@@ -60,8 +60,6 @@ async def sync_system_prompt():
         logger.debug(f"更新了 {updated} 条 system 记录", "zhipu_toolkit")
     except Exception as e:
         logger.error("同步系统提示词失败", "zhipu_toolkit", e=e)
-    finally:
-        return
 
 
 @scheduler.scheduled_job(

--- a/zhipu_toolkit/handler.py
+++ b/zhipu_toolkit/handler.py
@@ -68,7 +68,7 @@ async def sync_system_prompt():
     minute=0,
 )
 async def delete_expired_chat_history():
-    day = ChatConfig.get("expire_day")
+    day = ChatConfig.get("EXPIRE_DAY")
     if day == -1:
         logger.info("跳过清理过期会话任务: 用户设置永不过期", "zhipu_toolkit")
         return
@@ -77,8 +77,6 @@ async def delete_expired_chat_history():
         logger.info(f"成功清理 {deleted} 条过期会话 记录", "zhipu_toolkit")
     except Exception as e:
         logger.error("清理过期会话记录失败", "zhipu_toolkit", e=e)
-    finally:
-        return
 
 
 draw_pic = on_alconna(

--- a/zhipu_toolkit/handler.py
+++ b/zhipu_toolkit/handler.py
@@ -15,6 +15,7 @@ from .model import ZhipuChatHistory
 from .utils import split_text, get_request_id
 
 require("nonebot_plugin_alconna")
+require("nonebot_plugin_uninfo")
 from nonebot.adapters import Bot, Event
 from nonebot.permission import SUPERUSER
 from nonebot_plugin_alconna import (

--- a/zhipu_toolkit/handler.py
+++ b/zhipu_toolkit/handler.py
@@ -60,6 +60,27 @@ async def sync_system_prompt():
         logger.debug(f"更新了 {updated} 条 system 记录", "zhipu_toolkit")
     except Exception as e:
         logger.error("同步系统提示词失败", "zhipu_toolkit", e=e)
+    finally:
+        return
+
+
+@scheduler.scheduled_job(
+    "cron",
+    hour=0,
+    minute=0,
+)
+async def delete_expired_chat_history():
+    day = ChatConfig.get("expire_day")
+    if day == -1:
+        logger.info("跳过清理过期会话任务: 用户设置永不过期", "zhipu_toolkit")
+        return
+    try:
+        deleted = await ZhipuChatHistory.delete_old_records(day)
+        logger.info(f"成功清理 {deleted} 条过期会话 记录", "zhipu_toolkit")
+    except Exception as e:
+        logger.error("清理过期会话记录失败", "zhipu_toolkit", e=e)
+    finally:
+        return
 
 
 draw_pic = on_alconna(

--- a/zhipu_toolkit/model.py
+++ b/zhipu_toolkit/model.py
@@ -127,7 +127,8 @@ class ZhipuChatHistory(Model):
     @classmethod
     async def delete_old_records(cls, days: int) -> int:
         """删除 n 天前的所有数据，保留 role='system'，但如果某个 uid 仅剩 system，则删除该 uid 的所有记录"""
-        cutoff_date = datetime.utcnow() - timedelta(days=days)
+        from datetime import timezone
+        cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
     
         async with in_transaction():
             # 删除 n 天前的所有非 `system` 记录

--- a/zhipu_toolkit/model.py
+++ b/zhipu_toolkit/model.py
@@ -124,7 +124,7 @@ class ZhipuChatHistory(Model):
             return 1
         return 0
 
-    @@classmethod
+    @classmethod
     async def delete_old_records(cls, days: int) -> int:
         """删除 n 天前的所有非 system 记录，若某 uid 仅剩 system，则删除该 uid 的所有记录"""
         cutoff = datetime.now(timezone.utc) - timedelta(days=days)

--- a/zhipu_toolkit/rule.py
+++ b/zhipu_toolkit/rule.py
@@ -1,4 +1,6 @@
 from nonebot.adapters import Event
+from nonebot import require
+require("nonebot_plugin_uninfo")
 from nonebot_plugin_uninfo import Uninfo
 
 from zhenxun.utils.platform import PlatformUtils

--- a/zhipu_toolkit/tools/ban.py
+++ b/zhipu_toolkit/tools/ban.py
@@ -70,6 +70,4 @@ class UnBanTool(Tool):
 
     async def UnBan(self, session, uid: str | None = None) -> str:
         uid = str(uid or session.user.id)
-        if await BanConsole.unban(uid):
-            return "取消拉黑用户成功"
-        return "取消拉黑用户失败: 该用户不在黑名单内"
+        return "取消拉黑用户成功" if await BanConsole.unban(uid) else "取消拉黑用户失败: 该用户不在黑名单内"

--- a/zhipu_toolkit/tools/ban.py
+++ b/zhipu_toolkit/tools/ban.py
@@ -1,0 +1,75 @@
+import random
+
+from zhenxun.models.ban_console import BanConsole
+from ._model import Tool
+
+
+class BanTool(Tool):
+    """拉黑用户的工具（支持随机时长）"""
+
+    def __init__(self):
+        super().__init__(
+            name="ban",
+            description=(
+                "拉黑指定用户或对话者，支持自定义拉黑时长（分钟）或随机1-100分钟，"
+                "返回操作结果（成功/失败原因）。"
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "uid": {
+                        "type": "string",
+                        "description": "目标用户UID，留空则拉黑对话者",
+                    },
+                    "minute": {
+                        "type": "integer",
+                        "description": "拉黑时长（分钟），不填则随机1-100分钟",
+                    },
+                },
+                "required": [],
+            },
+            func=self.Ban,
+        )
+
+    async def Ban(
+        self, session, uid: str | None = None, minute: int | None = None
+    ) -> str:
+        uid = str(uid or session.user.id)
+        mute_time = minute or random.randint(1, 100)
+        try:
+            await BanConsole.ban(
+                uid,
+                None,
+                9999,
+                mute_time * 60,
+            )
+            return f"拉黑用户成功, 拉黑时长: {mute_time}分钟"
+        except Exception as e:
+            return f"拉黑用户失败, 原因: {e!s}"
+
+
+class UnBanTool(Tool):
+    """取消用户禁言的工具"""
+
+    def __init__(self):
+        super().__init__(
+            name="unban",
+            description="取消指定用户或对话者的拉黑状态，返回操作结果（成功/失败原因）。",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "uid": {
+                        "type": "string",
+                        "description": "目标用户UID，留空则取消对话者的拉黑",
+                    },
+                },
+                "required": [],
+            },
+            func=self.UnBan,
+        )
+
+    async def UnBan(self, session, uid: str | None = None) -> str:
+        uid = str(uid or session.user.id)
+        if await BanConsole.unban(uid):
+            return "取消拉黑用户成功"
+        return "取消拉黑用户失败: 该用户不在黑名单内"

--- a/zhipu_toolkit/tools/ban.py
+++ b/zhipu_toolkit/tools/ban.py
@@ -49,7 +49,7 @@ class BanTool(Tool):
 
 
 class UnBanTool(Tool):
-    """取消用户禁言的工具"""
+    """取消拉黑用户的工具"""
 
     def __init__(self):
         super().__init__(

--- a/zhipu_toolkit/tools/mute.py
+++ b/zhipu_toolkit/tools/mute.py
@@ -1,10 +1,6 @@
 import random
 
 from nonebot import get_bot
-
-from zhenxun.utils.rules import ensure_group
-from zhenxun.models.ban_console import BanConsole
-
 from ._model import Tool
 
 
@@ -23,7 +19,7 @@ class MuteTool(Tool):
                 "properties": {
                     "uid": {
                         "type": "string",
-                        "description": "目标用户UID，留空则禁言指令发起者",
+                        "description": "目标用户UID，留空则禁言对话者",
                     },
                     "minute": {
                         "type": "integer",
@@ -45,9 +41,9 @@ class MuteTool(Tool):
         mute_time = minute or random.randint(1, 100)
         try:
             await PlatformUtils.ban_user(bot, uid, gid, mute_time)
-            return f"禁言成功, 禁言时长: {mute_time}分钟"
+            return f"禁言用户成功, 禁言时长: {mute_time}分钟"
         except Exception as e:
-            return f"禁言失败, 原因: {e!s}"
+            return f"禁言用户失败, 原因: {e!s}"
 
 
 class UnMuteTool(Tool):
@@ -62,7 +58,7 @@ class UnMuteTool(Tool):
                 "properties": {
                     "uid": {
                         "type": "string",
-                        "description": "目标用户UID，留空则取消指令发起者的禁言",
+                        "description": "目标用户UID，留空则取消对话者的禁言",
                     },
                 },
                 "required": [],
@@ -76,6 +72,6 @@ class UnMuteTool(Tool):
         uid = str(uid or session.user.id)
         try:
             await PlatformUtils.ban_user(bot, uid, gid, 0)
-            return "取消禁言成功"
+            return "取消禁言用户成功"
         except Exception as e:
-            return f"取消禁言失败, 原因: {e!s}"
+            return f"取消禁言用户失败, 原因: {e!s}"

--- a/zhipu_toolkit/utils.py
+++ b/zhipu_toolkit/utils.py
@@ -5,7 +5,9 @@ import re
 import shutil
 import uuid
 
-from nonebot import get_bot
+from nonebot import get_bot, require
+require("nonebot_plugin_alconna")
+require("nonebot_plugin_uninfo")
 from nonebot_plugin_alconna import At, Image, Text, UniMsg
 from nonebot_plugin_uninfo import Session, Uninfo
 from zhipuai import ZhipuAI


### PR DESCRIPTION
## Sourcery 总结

通过添加记录删除例程和计划清理来优化聊天记录保留，并通过可配置的限制来增强消息缓存和长度约束

新功能：
- 添加 `delete_latest_record` 方法以删除用户最近的聊天条目
- 添加 `delete_old_records` 方法以清除早于可配置天数的聊天记录
- 安排每日任务以根据 `EXPIRE_DAY` 配置删除过期的聊天记录
- 引入 `EXPIRE_DAY` 和 `WORD_LIMIT` 配置选项

增强功能：
- 在缓存群组消息时强制执行 255 个字符的限制，并跳过超大条目并发出警告
- 将硬编码的 4095 个 token 限制替换为传入消息的可配置 `WORD_LIMIT`
- 在流式传输完成后删除最后插入的聊天记录，以避免过时的条目
- 在 `cache_group_message` 中预先计算消息字符串，以消除冗余的异步调用
- 在加载历史数据时显式初始化成功和失败计数器

杂项：
- 将插件版本提升至 1.7

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过添加删除例程和计划的清理、可配置的过期时间和消息长度限制，以及改进消息缓存和限制执行，来优化聊天记录保留。

新功能：
- 添加删除最新和过期聊天记录的方法，并根据 EXPIRE_DAY 设置安排每日清理作业
- 引入 EXPIRE_DAY 和 WORD_LIMIT 配置选项，以控制记录保留期限和消息长度限制

增强功能：
- 在缓存群组消息时强制执行 255 个字符的限制，跳过超大条目并发出警告
- 在聊天处理中，将硬编码的 4095 个 token 限制替换为可配置的 WORD_LIMIT，并更新相关的警告和错误响应
- 在流式传输后删除最近插入的聊天记录，以防止过时的条目
- 预先计算群组消息字符串，以消除冗余的异步转换
- 在加载历史聊天数据时，显式初始化成功和失败计数器

杂项：
- 将插件版本提升至 1.7

<details>
<summary>Original summary in English</summary>

好的，这是将提供的拉取请求摘要翻译成中文的结果：

## Sourcery 总结

通过添加记录删除例程、调度每日过期清理以及引入可配置的保留期限和消息长度限制，优化聊天记录管理。

新功能：
- 添加删除最新和旧聊天记录的方法
- 安排每日任务以根据 EXPIRE_DAY 清除过期的记录
- 引入 EXPIRE_DAY 和 WORD_LIMIT 配置选项
- 将插件版本提升至 1.7

增强功能：
- 对缓存的群组消息强制执行 255 个字符的限制，并对超大条目发出警告
- 在聊天处理中，用可配置的 WORD_LIMIT 替换硬编码的 token 限制，并更新相关的警告
- 在流式传输错误或完成后自动删除陈旧的聊天条目
- 在缓存中预先计算消息字符串，以消除冗余的异步调用
- 在加载聊天记录时，显式初始化成功和失败计数器

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

优化聊天记录管理，添加记录删除例程、可配置的过期时间和长度限制，并引入计划清理；同时添加用户封禁/解封工具并更新版本。

新功能：
- 添加 `delete_latest_record` 和 `delete_old_records` 方法来管理聊天记录
- 计划每日清理任务，根据 `EXPIRE_DAY` 删除过期的聊天记录
- 引入 `EXPIRE_DAY` 和 `WORD_LIMIT` 配置选项
- 添加用于管理用户封禁的封禁和解封工具

增强功能：
- 在缓存群组消息时强制执行 255 个字符的限制，并跳过超大条目并发出警告
- 将固定的 4095 个 token 限制替换为可配置的 `WORD_LIMIT`，并更新相关的警告和响应
- 在流式传输错误或完成后自动删除最新的聊天条目，以避免陈旧记录
- 在缓存中预先计算消息字符串，以消除冗余的异步转换
- 在加载历史聊天数据时显式初始化成功和失败计数器

杂项：
- 将插件版本提升至 1.7

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

优化聊天记录管理，通过添加例程来删除最新的和过期的条目，并进行计划的清理，引入可配置的保留期限和消息长度限制，在缓存和聊天处理中强制执行这些限制，并添加封禁/解封管理工具。

新功能：
- 添加删除用户最新聊天记录以及清除早于指定天数的记录的方法
- 安排每日任务，根据 EXPIRE_DAY 设置清除过期的聊天记录
- 引入 EXPIRE_DAY 和 WORD_LIMIT 配置选项来控制记录过期和消息长度
- 添加用于将用户列入黑名单的可自定义时长的封禁和解封工具

增强功能：
- 在缓存群组消息时强制执行 255 个字符的限制，并跳过超大条目并发出警告
- 在普通聊天处理中，用可配置的 WORD_LIMIT 替换硬编码的 token 限制，并更新相关的警告和错误
- 在流式传输错误或完成后自动删除最后插入的聊天记录，以避免过时的条目
- 在 cache_group_message 中预先计算消息字符串，以消除冗余的异步调用
- 加载历史聊天数据时，显式初始化成功和失败计数器

日常维护：
- 将插件版本提升至 1.7

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

优化聊天记录保留策略，引入删除例程，引入可配置的保留期限和消息长度限制，添加计划清理和用户管理工具，并提升插件版本。

新功能：
- 添加 `delete_latest_record` 和 `delete_old_records` 方法，并添加每日任务以根据 `EXPIRE_DAY` 清除过期的聊天记录
- 引入 `EXPIRE_DAY` 和 `WORD_LIMIT` 配置选项来控制历史记录保留和消息长度
- 添加用于用户管理的禁言 (mute)、取消禁言 (unmute)、封禁 (ban) 和取消封禁 (unban) 工具

增强功能：
- 对缓存的群组消息强制执行 255 个字符的限制，跳过并警告超大条目
- 将硬编码的 token 限制替换为可配置的 `WORD_LIMIT`，并在流式传输完成或出错后删除过时的条目
- 在缓存中预先计算消息字符串，并显式初始化成功/失败计数器以简化性能

杂项：
- 插件版本提升至 1.7

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize chat history retention with deletion routines, introduce configurable retention and message length limits, add scheduled cleanup and user moderation tools, and bump plugin version.

New Features:
- Add delete_latest_record and delete_old_records methods with a daily job to clear expired chat history based on EXPIRE_DAY
- Introduce EXPIRE_DAY and WORD_LIMIT configuration options to control history retention and message length
- Add mute, unmute, ban, and unban tools for user moderation

Enhancements:
- Enforce a 255-character limit on cached group messages, skipping and warning on oversized entries
- Replace hardcoded token limit with configurable WORD_LIMIT and remove stale entries after streaming completion or errors
- Precompute message strings in caching and explicitly initialize success/failure counters to streamline performance

Chores:
- Bump plugin version to 1.7

</details>

</details>

</details>

</details>

</details>

</details>