### PR TITLE
feat: 增加“单次对话消息最大分割段数”配置

### DIFF
--- a/zhipu_toolkit/__init__.py
+++ b/zhipu_toolkit/__init__.py
@@ -122,6 +122,12 @@ __plugin_meta__ = PluginMetadata(
                 default_value=1000,
             ),
             RegisterConfig(
+                key="TEXT_MAX_SPLIT",
+                value=3,
+                help="单次对话消息最大分割段数, 0表示无限分割, -1表示不分割",
+                default_value=3,
+            ),
+            RegisterConfig(
                 key="SOUL",
                 value=None,
                 help="已弃用",

--- a/zhipu_toolkit/handler.py
+++ b/zhipu_toolkit/handler.py
@@ -278,8 +278,7 @@ async def zhipu_chat(bot, event: Event, msg: UniMsg, session: Session = UniSessi
                     image = i
                     break
         result = await ChatManager.normal_chat_result(image + msg, session)
-        text_max_split = ChatConfig.get("TEXT_MAX_SPLIT")
-        for r, delay in await split_text(result, text_max_split):
+        for r, delay in await split_text(result):
             await UniMessage(r).send(reply_to=reply)
             await cache_group_message(UniMessage(r), session, BotConfig.self_nickname)
             await asyncio.sleep(delay)

--- a/zhipu_toolkit/handler.py
+++ b/zhipu_toolkit/handler.py
@@ -278,7 +278,8 @@ async def zhipu_chat(bot, event: Event, msg: UniMsg, session: Session = UniSessi
                     image = i
                     break
         result = await ChatManager.normal_chat_result(image + msg, session)
-        for r, delay in await split_text(result):
+        text_max_split = ChatConfig.get("TEXT_MAX_SPLIT")
+        for r, delay in await split_text(result, text_max_split):
             await UniMessage(r).send(reply_to=reply)
             await cache_group_message(UniMessage(r), session, BotConfig.self_nickname)
             await asyncio.sleep(delay)

--- a/zhipu_toolkit/utils.py
+++ b/zhipu_toolkit/utils.py
@@ -118,7 +118,7 @@ async def __split_text(text: str, pattern: str, maxsplit: int) -> list[str]:
     return re.split(pattern, text, maxsplit)
 
 
-async def split_text(text: str) -> list[tuple[str, float]]:
+async def split_text(text: str, maxsplit: int = 3) -> list[tuple[str, float]]:
     """文本切割"""
     results = []
     
@@ -127,9 +127,9 @@ async def split_text(text: str) -> list[tuple[str, float]]:
         return [(await str2msg(text.strip()), 1.0)]
     
     split_list = [
-        s for s in await __split_text(text, r"[。？！\n]+", 3)
+        s for s in await __split_text(text, r"[。？！\n]+", maxsplit)
         if s.strip()
-    ]
+    ] if maxsplit > -1 else [ text ]
     
     for r in split_list:
         next_char_index = text.find(r) + len(r)

--- a/zhipu_toolkit/utils.py
+++ b/zhipu_toolkit/utils.py
@@ -118,18 +118,18 @@ async def __split_text(text: str, pattern: str, maxsplit: int) -> list[str]:
     return re.split(pattern, text, maxsplit)
 
 
-async def split_text(text: str, maxsplit: int = 3) -> list[tuple[str, float]]:
+async def split_text(text: str) -> list[tuple[str, float]]:
     """文本切割"""
     results = []
     
     # 解决单个符号被忽略的问题
     if len(text.strip()) == 1:
         return [(await str2msg(text.strip()), 1.0)]
-    
+    max_split = ChatConfig.get("TEXT_MAX_SPLIT")
     split_list = [
-        s for s in await __split_text(text, r"[。？！\n]+", maxsplit)
+        s for s in await __split_text(text, r"[。？！\n]+", max_split)
         if s.strip()
-    ] if maxsplit > -1 else [ text ]
+    ] if max_split > -1 else [ text ]
     
     for r in split_list:
         next_char_index = text.find(r) + len(r)


### PR DESCRIPTION
好的，这是将 pull request 摘要翻译成中文的结果：

## Sourcery 总结

添加一个新的 TEXT_MAX_SPLIT 设置，用于可配置的消息分割，重构文本分割实用程序以遵守此设置，并将其应用于聊天处理程序。

新功能：
- 添加 TEXT_MAX_SPLIT 配置键，以控制每个对话消息段的最大数量

增强功能：
- 更新 split_text 实用程序以接受 maxsplit 参数，并处理无限制 (0) 或不分割 (-1) 的情况
- 将 TEXT_MAX_SPLIT 配置集成到 zhipu_chat 处理程序中，以应用自定义分割计数

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new TEXT_MAX_SPLIT setting for configurable message segmentation, refactor the text splitting utility to respect this setting, and apply it in the chat handler.

New Features:
- Add TEXT_MAX_SPLIT configuration key to control the maximum number of message segments per dialog

Enhancements:
- Update split_text utility to accept a maxsplit parameter and handle unlimited (0) or no-split (-1) cases
- Integrate TEXT_MAX_SPLIT config into the zhipu_chat handler to apply the custom split count

</details>