### PR TITLE
feat: 支持群聊/私聊戳一戳

### DIFF
--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -226,7 +226,7 @@ class ChatManager:
         )
         if not getattr(result, "content", None):
             logger.warning(f"Missing result.content: {result}", "zhipu_toolkit")
-            raise ValueError("Missing result.content")
+            # raise ValueError("Missing result.content")
         if result.error_code == 1:
             logger.info(
                 f"USERNAME `{username}` 问题: {message} ---- 触发内容审查",

--- a/zhipu_toolkit/tools/poke.py
+++ b/zhipu_toolkit/tools/poke.py
@@ -1,0 +1,34 @@
+import nonebot
+from ._model import Tool
+from nonebot_plugin_alconna import UniMessage, At
+
+class PokeMsg(Tool):
+    """工具类：用于戳一戳指定用户"""
+
+    def __init__(self):
+        super().__init__(
+            name="poke_user",
+            description=(
+                "用于戳一戳指定用户"
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "uid": {
+                        "type": "string",
+                        "description": "需要戳一戳的用户唯一标识符（UID）",
+                    }
+                },
+                "required": ["uid"],
+            },
+            func=self._generate_poke_msg,
+        )
+
+    async def _generate_poke_msg(self, uid: str, session) -> str:
+        scene = session.scene
+        gid = scene.id if scene.is_group else None # 传入此参数按group_poke发送,否则按friend_poke发送
+        bot = nonebot.get_bot()
+        if not uid.strip():
+            raise ValueError("uid cannot be empty")
+        await bot.send_poke(group_id=gid, user_id=uid)
+        return "已成功发送戳一戳消息"

--- a/zhipu_toolkit/tools/poke.py
+++ b/zhipu_toolkit/tools/poke.py
@@ -10,13 +10,14 @@ class PokeMsg(Tool):
             name="poke_user",
             description=(
                 "用于戳一戳指定用户"
+                "传入用户id发送戳一戳信息，支持群聊/私聊"
             ),
             parameters={
                 "type": "object",
                 "properties": {
                     "uid": {
                         "type": "string",
-                        "description": "需要戳一戳的用户唯一标识符（UID）",
+                        "description": "需要戳一戳的用户id",
                     }
                 },
                 "required": ["uid"],
@@ -25,10 +26,17 @@ class PokeMsg(Tool):
         )
 
     async def _generate_poke_msg(self, uid: str, session) -> str:
-        scene = session.scene
-        gid = scene.id if scene.is_group else None # 传入此参数按group_poke发送,否则按friend_poke发送
-        bot = nonebot.get_bot()
         if not uid.strip():
             raise ValueError("uid cannot be empty")
-        await bot.send_poke(group_id=gid, user_id=uid)
+        scene = session.scene
+        bot = nonebot.get_bot()
+        if scene.is_group:
+            gid = scene.id
+            await bot.call_api(
+                "group_poke", user_id=uid, group_id=gid
+                )
+        else:
+            await bot.call_api(
+                "friend_poke", user_id=uid
+                )
         return "已成功发送戳一戳消息"

--- a/zhipu_toolkit/tools/poke.py
+++ b/zhipu_toolkit/tools/poke.py
@@ -1,6 +1,6 @@
 import nonebot
 from ._model import Tool
-from nonebot_plugin_alconna import UniMessage, At
+from zhenxun.services.log import logger
 
 class PokeMsg(Tool):
     """工具类：用于戳一戳指定用户"""
@@ -30,13 +30,24 @@ class PokeMsg(Tool):
             raise ValueError("uid cannot be empty")
         scene = session.scene
         bot = nonebot.get_bot()
-        if scene.is_group:
-            gid = scene.id
-            await bot.call_api(
-                "group_poke", user_id=uid, group_id=gid
+        try:
+            await bot.call_api("poke", qq=uid)
+        except Exception:
+            try:
+                if scene.is_group:
+                    gid = scene.id
+                    await bot.call_api(
+                        "group_poke", user_id=uid, group_id=gid
+                        )
+                else:
+                    await bot.call_api(
+                        "friend_poke", user_id=uid
+                        )
+            except Exception:
+                logger.warning(
+                    "戳一戳发送失败，可能是协议端不支持...",
+                    "[zhipu_toolkit][tool]戳一戳",
+                    session=session,
                 )
-        else:
-            await bot.call_api(
-                "friend_poke", user_id=uid
-                )
+                return "戳一戳发送失败，可能是协议端不支持..."
         return "已成功发送戳一戳消息"


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/35bdb44f-7f50-4a58-bcc2-aa1be1b0e5bf)

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

引入一个新的 Poke 工具，支持在群聊和私聊中发送 Poke 提醒，并调整了错误处理方式，在缺少聊天内容时跳过引发错误。

新功能：
- 添加 PokeMsg 工具，用于向群聊或私聊中指定的用户发送 Poke 消息。
- 实现基于会话（群聊 vs. 私聊）的上下文感知 Poke 分发。

增强功能：
- 禁用在聊天结果缺少内容时引发异常，以避免中断工作流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new poke tool that supports sending poke notifications in both group and private conversations, and adjust error handling to skip raising errors on missing chat content.

New Features:
- Add a PokeMsg tool for sending poke messages to specified users in group or private chats.
- Implement context-aware poke dispatch based on session (group vs. private chat).

Enhancements:
- Disable raising an exception when chat results lack content to avoid interrupting workflows.

</details>