### PR TITLE
feat(zhipu_toolkit): 添加定时同步功能和内存缓存优化

### DIFF
--- a/zhipu_toolkit/config.py
+++ b/zhipu_toolkit/config.py
@@ -55,91 +55,65 @@ IMPERSONATION_PROMPT = """
 - 有概率玩谐音梗
 """
 
-PROMPT: str = ""
-_PROMPT_MTIME: float | None = None
+PROMPT_FILE = DATA_PATH / "zhipu_toolkit" / "prompt.txt"
+PROMPT_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+DEFAULT_PROMPT = """..."""
 
 
-async def _load_prompt_from_file() -> tuple[str, float]:
-    """真正从文件读取 PROMPT 的内部工具函数，只负责文件 I/O，保持纯函数。
+class PromptCache:
+    def __init__(self) -> None:
+        self._content: str = ""
+        self._mtime: float | None = None
 
-    返回:
-        tuple[str, float]: (文件内容, 文件最近修改时间 mtime)。
-    """
-    async with aiofiles.open(PROMPT_FILE, encoding="utf-8") as f:
-        content = await f.read()
-    mtime = PROMPT_FILE.stat().st_mtime
-    return content, mtime
+    async def _ensure_file(self) -> None:
+        if PROMPT_FILE.exists():
+            return
+        logger.warning("PROMPT文件不存在，正在初始化...", "zhipu_toolkit")
+        async with aiofiles.open(PROMPT_FILE, "w", encoding="utf-8") as f:
+            await f.write(DEFAULT_PROMPT)
+
+    async def _read_file(self) -> tuple[str, float]:
+        async with aiofiles.open(PROMPT_FILE, encoding="utf-8") as f:
+            content = await f.read()
+        mtime = PROMPT_FILE.stat().st_mtime
+        return content, mtime
+
+    async def get(self) -> str:
+        """懒加载 + mtime 检查 + 容错."""
+        await self._ensure_file()
+        try:
+            content, mtime = await self._read_file()
+            if self._mtime is None or mtime != self._mtime:
+                self._content, self._mtime = content, mtime
+        except Exception as e:
+            logger.error(
+                "PROMPT 读取失败，使用现有 PROMPT 或 DEFAULT_PROMPT",
+                "zhipu_toolkit",
+                e=e,
+            )
+            if not self._content:
+                self._content = DEFAULT_PROMPT
+        return self._content or DEFAULT_PROMPT
+
+    async def refresh_if_changed(self) -> str:
+        """给 scheduler 用：预拉取并刷新缓存（如有变更）."""
+        return await self.get()
 
 
-async def _refresh_prompt(force: bool = False) -> str:
-    """统一刷新 PROMPT 的入口，负责是否读文件、更新全局状态并封装异常处理。
+PROMPT_CACHE = PromptCache()
 
-    行为:
-        - 当 force=True 时，无视 mtime 直接从文件读取并更新 PROMPT 与 _PROMPT_MTIME；
-        - 当 force=False 时，仅在检测到文件存在且 mtime 变化时才重新读取；
-        - 如果文件不存在，则创建并写入 DEFAULT_PROMPT，再加载；
-        - 任何异常情况下都不会清空 PROMPT，而是返回已有 PROMPT 或 DEFAULT_PROMPT。
-    """
-    global PROMPT, _PROMPT_MTIME
 
-    try:
-        if not PROMPT_FILE.exists():
-            logger.warning("PROMPT文件不存在，正在初始化...", "zhipu_toolkit")
-            async with aiofiles.open(PROMPT_FILE, "w", encoding="utf-8") as f:
-                await f.write(DEFAULT_PROMPT)
-            PROMPT, _PROMPT_MTIME = DEFAULT_PROMPT, PROMPT_FILE.stat().st_mtime
-            return PROMPT
-
-        current_mtime = PROMPT_FILE.stat().st_mtime
-
-        # 如果不强制刷新且 mtime 未变化，则直接返回当前 PROMPT
-        if not force and _PROMPT_MTIME is not None and current_mtime == _PROMPT_MTIME:
-            return PROMPT or DEFAULT_PROMPT
-
-        # 需要从文件读取
-        content, mtime = await _load_prompt_from_file()
-        PROMPT = content
-        _PROMPT_MTIME = mtime
-        return PROMPT
-    except Exception as e:
-        logger.error(
-            "PROMPT 刷新失败，使用现有 PROMPT 或 DEFAULT_PROMPT",
-            "zhipu_toolkit",
-            e=e,
-        )
-        return PROMPT or DEFAULT_PROMPT
+async def get_prompt() -> str:
+    return await PROMPT_CACHE.get()
 
 
 @scheduler.scheduled_job("interval", minutes=30, id="zhipu_sync_prompt_job")
 async def sync_prompt_job() -> None:
-    """每隔 30 分钟同步一次 PROMPT，如果文件内容有修改。
-
-    规则:
-        - 仅在文件 mtime 变化时才重新读取；
-        - 读取失败不会清空 PROMPT，而是保留旧值。
-    """
-    old_prompt = PROMPT
-    new_prompt = await _refresh_prompt(force=False)
+    old_prompt = PROMPT_CACHE._content
+    new_prompt = await PROMPT_CACHE.refresh_if_changed()
     if new_prompt != old_prompt:
         logger.info("PROMPT 文件有更新，已同步到内存", "zhipu_toolkit")
-    else:
-        logger.debug("PROMPT文件未修改，跳过同步", "zhipu_toolkit")
-
-
-async def get_prompt() -> str:
-    """对外提供的获取 PROMPT 的函数。
-
-    行为:
-        - 如果全局 PROMPT 为空（例如系统刚启动还没调用 init_prompt），会尝试加载一次；
-        - 正常情况下直接返回内存中的 PROMPT，并在需要时由 _refresh_prompt 负责更新。
-    """
-    if not PROMPT:
-        # 懒加载兜底：在未显式初始化时也能工作
-        prompt = await _refresh_prompt(force=True)
-        logger.info("get_prompt 懒加载 PROMPT 完成", "zhipu_toolkit")
-        return prompt
-
-    return PROMPT
 
 
 class ChatConfig:

--- a/zhipu_toolkit/config.py
+++ b/zhipu_toolkit/config.py
@@ -59,41 +59,55 @@ PROMPT: str = ""
 _PROMPT_MTIME: float | None = None
 
 
-async def _load_prompt_from_file() -> str:
-    """真正从文件读取 PROMPT 的内部工具函数，不做调度，只负责读取和初始化文件。"""
-    global _PROMPT_MTIME
+async def _load_prompt_from_file() -> tuple[str, float]:
+    """真正从文件读取 PROMPT 的内部工具函数，只负责文件 I/O，保持纯函数。
 
-    try:
-        async with aiofiles.open(PROMPT_FILE, encoding="utf-8") as f:
-            content = await f.read()
-        # 同步记录当前文件的 mtime，供后续比对
-        _PROMPT_MTIME = PROMPT_FILE.stat().st_mtime
-        return content
-    except FileNotFoundError:
-        logger.warning("PROMPT文件不存在，正在初始化...", "zhipu_toolkit")
-        async with aiofiles.open(PROMPT_FILE, "w", encoding="utf-8") as f:
-            await f.write(DEFAULT_PROMPT)
-        # 初始化时，同样记录 mtime
-        _PROMPT_MTIME = PROMPT_FILE.stat().st_mtime
-        return DEFAULT_PROMPT
-    except Exception as e:
-        logger.error(
-            "PROMPT读取失败，使用 PROMPT or DEFAULT_PROMPT", "zhipu_toolkit", e=e
-        )
-        # 出错时不更新 mtime，保持上一次有效值
-        return PROMPT or DEFAULT_PROMPT
+    返回:
+        tuple[str, float]: (文件内容, 文件最近修改时间 mtime)。
+    """
+    async with aiofiles.open(PROMPT_FILE, encoding="utf-8") as f:
+        content = await f.read()
+    mtime = PROMPT_FILE.stat().st_mtime
+    return content, mtime
 
 
-async def init_prompt() -> None:
-    """在插件加载/启动时调用的一次性初始化函数。
+async def _refresh_prompt(force: bool = False) -> str:
+    """统一刷新 PROMPT 的入口，负责是否读文件、更新全局状态并封装异常处理。
 
     行为:
-        - 如果 PROMPT_FILE 不存在，会创建并写入 DEFAULT_PROMPT；
-        - 把文件内容读入并赋值给全局 PROMPT；
-        - 记录当前 mtime，供后续定时任务检测变化。
+        - 当 force=True 时，无视 mtime 直接从文件读取并更新 PROMPT 与 _PROMPT_MTIME；
+        - 当 force=False 时，仅在检测到文件存在且 mtime 变化时才重新读取；
+        - 如果文件不存在，则创建并写入 DEFAULT_PROMPT，再加载；
+        - 任何异常情况下都不会清空 PROMPT，而是返回已有 PROMPT 或 DEFAULT_PROMPT。
     """
-    global PROMPT
-    PROMPT = await _load_prompt_from_file()
+    global PROMPT, _PROMPT_MTIME
+
+    try:
+        if not PROMPT_FILE.exists():
+            logger.warning("PROMPT文件不存在，正在初始化...", "zhipu_toolkit")
+            async with aiofiles.open(PROMPT_FILE, "w", encoding="utf-8") as f:
+                await f.write(DEFAULT_PROMPT)
+            PROMPT, _PROMPT_MTIME = DEFAULT_PROMPT, PROMPT_FILE.stat().st_mtime
+            return PROMPT
+
+        current_mtime = PROMPT_FILE.stat().st_mtime
+
+        # 如果不强制刷新且 mtime 未变化，则直接返回当前 PROMPT
+        if not force and _PROMPT_MTIME is not None and current_mtime == _PROMPT_MTIME:
+            return PROMPT or DEFAULT_PROMPT
+
+        # 需要从文件读取
+        content, mtime = await _load_prompt_from_file()
+        PROMPT = content
+        _PROMPT_MTIME = mtime
+        return PROMPT
+    except Exception as e:
+        logger.error(
+            "PROMPT 刷新失败，使用现有 PROMPT 或 DEFAULT_PROMPT",
+            "zhipu_toolkit",
+            e=e,
+        )
+        return PROMPT or DEFAULT_PROMPT
 
 
 @scheduler.scheduled_job("interval", minutes=30, id="zhipu_sync_prompt_job")
@@ -104,29 +118,12 @@ async def sync_prompt_job() -> None:
         - 仅在文件 mtime 变化时才重新读取；
         - 读取失败不会清空 PROMPT，而是保留旧值。
     """
-    global PROMPT, _PROMPT_MTIME
-
-    try:
-        if not PROMPT_FILE.exists():
-            # 如果文件被手动删了，重新初始化
-            logger.warning("PROMPT文件被删除，重新初始化...", "zhipu_toolkit")
-            PROMPT = await _load_prompt_from_file()
-            logger.info("PROMPT 文件已重新初始化并同步到内存", "zhipu_toolkit")
-            return
-
-        current_mtime = PROMPT_FILE.stat().st_mtime
-        if _PROMPT_MTIME is not None and current_mtime == _PROMPT_MTIME:
-            # 文件未修改，跳过
-            logger.debug("PROMPT文件未修改，跳过同步", "zhipu_toolkit")
-            return
-
-        # 文件有变化，重新加载
-        new_prompt = await _load_prompt_from_file()
-        PROMPT = new_prompt
+    old_prompt = PROMPT
+    new_prompt = await _refresh_prompt(force=False)
+    if new_prompt != old_prompt:
         logger.info("PROMPT 文件有更新，已同步到内存", "zhipu_toolkit")
-    except Exception as e:
-        # 避免定时任务异常中断，保留旧 PROMPT
-        logger.error("PROMPT同步任务出错，保留现有 PROMPT", "zhipu_toolkit", e=e)
+    else:
+        logger.debug("PROMPT文件未修改，跳过同步", "zhipu_toolkit")
 
 
 async def get_prompt() -> str:
@@ -134,14 +131,13 @@ async def get_prompt() -> str:
 
     行为:
         - 如果全局 PROMPT 为空（例如系统刚启动还没调用 init_prompt），会尝试加载一次；
-        - 正常情况下直接返回内存中的 PROMPT。
+        - 正常情况下直接返回内存中的 PROMPT，并在需要时由 _refresh_prompt 负责更新。
     """
-    global PROMPT
-
     if not PROMPT:
         # 懒加载兜底：在未显式初始化时也能工作
-        PROMPT = await _load_prompt_from_file()
+        prompt = await _refresh_prompt(force=True)
         logger.info("get_prompt 懒加载 PROMPT 完成", "zhipu_toolkit")
+        return prompt
 
     return PROMPT
 

--- a/zhipu_toolkit/config.py
+++ b/zhipu_toolkit/config.py
@@ -1,5 +1,6 @@
 import aiofiles
 import nonebot
+from nonebot_plugin_apscheduler import scheduler
 from pydantic import BaseModel, Extra
 
 from zhenxun.configs.config import Config
@@ -9,9 +10,7 @@ from zhenxun.services.log import logger
 PROMPT_FILE = DATA_PATH / "zhipu_toolkit" / "prompt.txt"
 PROMPT_FILE.parent.mkdir(parents=True, exist_ok=True)
 
-DEFAULT_PROMPT = (
-    """你是绪山真寻，现在扮演青涩纯真的邻家学妹，性格活泼开朗，像小太阳一样充满活力！拥有棉花糖"""
-    """般软糯的外表。 内心隐藏着一丝小恶魔。
+DEFAULT_PROMPT = """你是绪山真寻，现在扮演青涩纯真的邻家学妹，性格活泼开朗，像小太阳一样充满活力！拥有棉花糖般软糯的外表。 内心隐藏着一丝小恶魔。
 行为特征：
 • 每句话都带着糖霜般甜糯的尾音「呐~」「啦~」
 • 偶尔使用颜文字表达活泼情绪 (✿◡‿◡) (≧∇≦)/
@@ -28,7 +27,6 @@ DEFAULT_PROMPT = (
 ღ 生气时像炸毛奶猫「喵、喵呜！」等类似的话
 ღ 关心人时会用元气满满的语气说「要、要好好吃饭哦!  不然会长不高高哒！」等类似的话
 """
-)
 
 IMPERSONATION_PROMPT = """
 【任务基本信息】
@@ -57,27 +55,102 @@ IMPERSONATION_PROMPT = """
 - 有概率玩谐音梗
 """
 
+PROMPT: str = ""
+_PROMPT_MTIME: float | None = None
+
+
+async def _load_prompt_from_file() -> str:
+    """真正从文件读取 PROMPT 的内部工具函数，不做调度，只负责读取和初始化文件。"""
+    global _PROMPT_MTIME
+
+    try:
+        async with aiofiles.open(PROMPT_FILE, encoding="utf-8") as f:
+            content = await f.read()
+        # 同步记录当前文件的 mtime，供后续比对
+        _PROMPT_MTIME = PROMPT_FILE.stat().st_mtime
+        return content
+    except FileNotFoundError:
+        logger.warning("PROMPT文件不存在，正在初始化...", "zhipu_toolkit")
+        async with aiofiles.open(PROMPT_FILE, "w", encoding="utf-8") as f:
+            await f.write(DEFAULT_PROMPT)
+        # 初始化时，同样记录 mtime
+        _PROMPT_MTIME = PROMPT_FILE.stat().st_mtime
+        return DEFAULT_PROMPT
+    except Exception as e:
+        logger.error(
+            "PROMPT读取失败，使用 PROMPT or DEFAULT_PROMPT", "zhipu_toolkit", e=e
+        )
+        # 出错时不更新 mtime，保持上一次有效值
+        return PROMPT or DEFAULT_PROMPT
+
+
+async def init_prompt() -> None:
+    """在插件加载/启动时调用的一次性初始化函数。
+
+    行为:
+        - 如果 PROMPT_FILE 不存在，会创建并写入 DEFAULT_PROMPT；
+        - 把文件内容读入并赋值给全局 PROMPT；
+        - 记录当前 mtime，供后续定时任务检测变化。
+    """
+    global PROMPT
+    PROMPT = await _load_prompt_from_file()
+
+
+@scheduler.scheduled_job("interval", minutes=30, id="zhipu_sync_prompt_job")
+async def sync_prompt_job() -> None:
+    """每隔 30 分钟同步一次 PROMPT，如果文件内容有修改。
+
+    规则:
+        - 仅在文件 mtime 变化时才重新读取；
+        - 读取失败不会清空 PROMPT，而是保留旧值。
+    """
+    global PROMPT, _PROMPT_MTIME
+
+    try:
+        if not PROMPT_FILE.exists():
+            # 如果文件被手动删了，重新初始化
+            logger.warning("PROMPT文件被删除，重新初始化...", "zhipu_toolkit")
+            PROMPT = await _load_prompt_from_file()
+            logger.info("PROMPT 文件已重新初始化并同步到内存", "zhipu_toolkit")
+            return
+
+        current_mtime = PROMPT_FILE.stat().st_mtime
+        if _PROMPT_MTIME is not None and current_mtime == _PROMPT_MTIME:
+            # 文件未修改，跳过
+            logger.debug("PROMPT文件未修改，跳过同步", "zhipu_toolkit")
+            return
+
+        # 文件有变化，重新加载
+        new_prompt = await _load_prompt_from_file()
+        PROMPT = new_prompt
+        logger.info("PROMPT 文件有更新，已同步到内存", "zhipu_toolkit")
+    except Exception as e:
+        # 避免定时任务异常中断，保留旧 PROMPT
+        logger.error("PROMPT同步任务出错，保留现有 PROMPT", "zhipu_toolkit", e=e)
+
+
+async def get_prompt() -> str:
+    """对外提供的获取 PROMPT 的函数。
+
+    行为:
+        - 如果全局 PROMPT 为空（例如系统刚启动还没调用 init_prompt），会尝试加载一次；
+        - 正常情况下直接返回内存中的 PROMPT。
+    """
+    global PROMPT
+
+    if not PROMPT:
+        # 懒加载兜底：在未显式初始化时也能工作
+        PROMPT = await _load_prompt_from_file()
+        logger.info("get_prompt 懒加载 PROMPT 完成", "zhipu_toolkit")
+
+    return PROMPT
+
 
 class ChatConfig:
     @classmethod
     def get(cls, key: str):
         key = key.upper()
         return Config.get_config("zhipu_toolkit", key)
-
-
-async def get_prompt() -> str:
-    """从 prompt.txt 文件中读取人设信息"""
-    try:
-        async with aiofiles.open(PROMPT_FILE, encoding="utf-8") as f:
-            return await f.read()
-    except FileNotFoundError:
-        logger.warning("PROMPT文件不存在，正在初始化...", "zhipu_toolkit")
-        async with aiofiles.open(PROMPT_FILE, "w", encoding="utf-8") as f:
-            await f.write(DEFAULT_PROMPT)
-        return DEFAULT_PROMPT
-    except Exception as e:
-        logger.error("PROMPT读取失败，使用 DEFAULT_PROMPT", "zhipu_toolkit", e=e)
-        return DEFAULT_PROMPT
 
 
 class PluginConfig(BaseModel, extra=Extra.ignore):

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -233,7 +233,10 @@ class ChatManager:
         round_records: list[dict] = [user_rec]
         # 拿到当前历史（含 system prompt），发送给模型
         result = await cls.get_zhipu_result(
-            uid, ChatConfig.get("CHAT_MODEL"), await cls.get_chat_history(uid), session
+            uid,
+            ChatConfig.get("CHAT_MODEL"),
+            (await cls.get_chat_history(uid)) + round_records,
+            session,
         )
 
         # 内容审查 / 输入违规
@@ -268,7 +271,7 @@ class ChatManager:
         tool_result = await cls.parse_function_call(
             uid, session, result.message.tool_calls
         )
-        if tool_result and result.message.tool_calls:
+        if tool_result is not None and result.message.tool_calls:
             # 工具执行结果记为 tool 角色的一条记录
             first_tool_call = result.message.tool_calls[0]
             round_records.append(
@@ -279,7 +282,7 @@ class ChatManager:
             result = await cls.get_zhipu_result(
                 uid,
                 ChatConfig.get("CHAT_MODEL"),
-                await cls.get_chat_history(uid),
+                await cls.get_chat_history(uid) + round_records,
                 session,
                 use_tool=False,
             )
@@ -330,8 +333,7 @@ class ChatManager:
                 # 缓存有效，更新访问时间并返回
                 cache_info["last_access"] = now
                 data: list = cache_info.get("data", [])
-                data.insert(0, {"role": "system", "content": await get_prompt()})
-                return data
+                return [{"role": "system", "content": await get_prompt()}] + data
 
         # 缓存不存在或已过期，从数据库获取完整历史
         history = await ZhipuChatHistory.get_history(uid)
@@ -340,8 +342,7 @@ class ChatManager:
             "last_access": now,
             "data": history[-CHAT_HISTORY_MAX_LEN:],
         }
-        history.insert(0, {"role": "system", "content": await get_prompt()})
-        return history
+        return [{"role": "system", "content": await get_prompt()}] + history
 
     @classmethod
     async def call_impersonation_ai(cls, session: Uninfo):

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import random
 
 from nonebot_plugin_alconna import AlconnaMatcher, Text, UniMessage, Video
+from nonebot_plugin_apscheduler import scheduler
 from nonebot_plugin_uninfo import Uninfo
 from zai import ZhipuAiClient as ZhipuAI
 from zai.types.chat.chat_completion import CompletionMessage, CompletionMessageToolCall
@@ -27,6 +28,41 @@ from .utils import (
     get_username_by_session,
     msg2str,
 )
+
+# ==== 简单的内存缓存，用于减少 normal_chat 频繁扫数据库 ====
+
+# 每个 uid 的对话缓存：
+#   uid -> { "last_access": datetime, "data": list[dict] }
+_CHAT_HISTORY_CACHE: dict[str, dict] = {}
+# 缓存有效期：多久没有访问就认为过期，自动丢弃
+CHAT_HISTORY_TTL_SECONDS = 30 * 60  # 30 分钟
+# 每个 uid 最多保留多少条历史记录，防止内存无限增长
+CHAT_HISTORY_MAX_LEN = 200
+
+
+def _prune_history_cache() -> None:
+    """清理超过 TTL 未访问的缓存，避免内存常驻过多 uid。"""
+    if not _CHAT_HISTORY_CACHE:
+        return
+    now = datetime.datetime.now()
+    to_delete = []
+    for uid, info in _CHAT_HISTORY_CACHE.items():
+        last_access: datetime.datetime = info.get("last_access", now)
+        if (now - last_access).total_seconds() > CHAT_HISTORY_TTL_SECONDS:
+            to_delete.append(uid)
+    for uid in to_delete:
+        _CHAT_HISTORY_CACHE.pop(uid, None)
+    if to_delete:
+        logger.debug(
+            f"normal_chat 缓存清理: 移除 {len(to_delete)} 个 uid 的历史缓存",
+            "zhipu_toolkit",
+        )
+
+
+@scheduler.scheduled_job("interval", minutes=20, id="zhipu_normal_chat_cache_prune")
+async def _prune_history_cache_job() -> None:
+    """定时任务：周期性清理 normal_chat 的内存缓存."""
+    _prune_history_cache()
 
 
 def hello() -> tuple[str, Path]:
@@ -69,6 +105,100 @@ async def check_video_task_status(task_id: str, action: type[AlconnaMatcher]):
 
 class ChatManager:
     @classmethod
+    def _build_user_record(cls, content: str, res_url: str | None = None) -> dict:
+        """构造一条 user 记录（仅内存使用，不直接写 DB）"""
+        return {
+            "role": "user",
+            "content": content,
+            "res_url": res_url,
+            "tool_calls": None,
+            "tool_call_id": None,
+        }
+
+    @classmethod
+    def _build_assistant_record(
+        cls,
+        message: CompletionMessage,
+    ) -> dict:
+        """构造一条 assistant 记录（仅内存使用，不直接写 DB）"""
+        tool_calls_serialized = (
+            [call.model_dump() for call in message.tool_calls]
+            if message.tool_calls
+            else None
+        )
+        return {
+            "role": message.role,
+            "content": message.content,
+            "res_url": None,
+            "tool_calls": tool_calls_serialized,
+            "tool_call_id": getattr(message, "tool_call_id", None),
+        }
+
+    @classmethod
+    def _build_tool_record(cls, content: str, tool_id: str) -> dict:
+        """构造一条 tool 调用记录（仅内存使用，不直接写 DB）"""
+        return {
+            "role": "tool",
+            "content": content,
+            "res_url": None,
+            "tool_calls": None,
+            "tool_call_id": tool_id,
+        }
+
+    @classmethod
+    async def _flush_round_history(cls, uid: str, records: list[dict]) -> None:
+        """将一轮对话（用户 + 模型返回 + 工具调用）写入数据库并同步更新缓存。
+
+        前提:
+            - 调用方保证只有在模型返回结构正常时才调用。
+        """
+        if not records:
+            return
+
+        # 1. 顺序写入数据库
+        for rec in records:
+            await ZhipuChatHistory.create(
+                uid=uid,
+                role=rec["role"],
+                content=rec["content"],
+                res_url=rec.get("res_url"),
+                tool_calls=rec.get("tool_calls"),
+                tool_call_id=rec.get("tool_call_id"),
+            )
+
+        # 2. 同步更新内存缓存
+        now = datetime.datetime.now()
+        cache_info = _CHAT_HISTORY_CACHE.get(uid)
+        if cache_info is None:
+            # 让下一次 get_chat_history 从 DB 重新加载即可
+            return
+
+        history: list = cache_info.get("data", [])
+        # 这里 history 的结构是 get_history 返回的那种形式：
+        # {"role":..., "content":(str or list[mix]),"tool_call_id":..., "tool_calls":...}  # noqa: E501
+        for rec in records:
+            if rec.get("res_url"):
+                content = [
+                    {"type": "text", "text": rec["content"]},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": rec["res_url"]},
+                    },
+                ]
+            else:
+                content = rec["content"]
+            history.append(
+                {
+                    "role": rec["role"],
+                    "content": content,
+                    "tool_call_id": rec.get("tool_call_id"),
+                    "tool_calls": rec.get("tool_calls"),
+                }
+            )
+        cache_info["data"] = history[-CHAT_HISTORY_MAX_LEN:]
+        cache_info["last_access"] = now
+
+    @classmethod
     async def normal_chat_result(cls, msg: UniMessage, session: Uninfo) -> str:
         match ChatConfig.get("CHAT_MODE"):
             case "user":
@@ -84,8 +214,8 @@ class ChatManager:
                 uid = "mix_mode"
             case _:
                 raise ValueError("CHAT_MODE must be 'user', 'group' or 'all'")
+
         username = get_username_by_session(session)
-        await cls.add_system_message(uid)
         message, img_url = await msg2str(msg, bool(ChatConfig.get("IS_MULTIMODAL")))
         word_limit = ChatConfig.get("WORD_LIMIT")
         if len(message) > word_limit:
@@ -95,38 +225,57 @@ class ChatManager:
                 session=session,
             )
             return f"超出管理员设置的字数限制: {word_limit}"
-        await cls.add_user_message(
-            format_usr_msg(username, session, message), uid, img_url
+
+        # 先把用户消息构造成记录，暂存内存
+        user_rec = cls._build_user_record(
+            format_usr_msg(username, session, message), img_url
         )
+        round_records: list[dict] = [user_rec]
+        # 拿到当前历史（含 system prompt），发送给模型
         result = await cls.get_zhipu_result(
             uid, ChatConfig.get("CHAT_MODEL"), await cls.get_chat_history(uid), session
         )
+
+        # 内容审查 / 输入违规
         if result.error_code == 1:
             logger.info(
                 f"USERNAME `{username}` 问题: {message} ---- 触发内容审查",
                 "zhipu_toolkit",
                 session=session,
             )
-            await ZhipuChatHistory.delete_latest_record(uid)
+            # 不写入任何历史，直接返回提示
             return result.content  # pyright: ignore[reportReturnType]
+
+        # 模型内部错误
         if result.error_code == 2:
             logger.error(
                 f"获取结果失败 e:{result.content}", "zhipu_toolkit", session=session
             )
-            await ZhipuChatHistory.delete_latest_record(uid)
             return f"出错了: {result.content}"
+
+        # 不应出现的情况：message 为空
         if result.message is None:
             logger.error(
                 f"Missing result.message for uid: {uid}, returning error."
                 f"Result content: {result.content}"
             )
-            await ZhipuChatHistory.delete_latest_record(uid)
             return f"出错了: {result.content}"
-        await cls.add_anytype_message(uid, result.message)
+
+        # 模型第一次回复（可能带 tool_calls），先暂存
+        round_records.append(cls._build_assistant_record(result.message))
+
+        # 工具调用：执行成功则增加 tool 记录 + 第二次模型回复
         tool_result = await cls.parse_function_call(
             uid, session, result.message.tool_calls
         )
-        if tool_result is not None:
+        if tool_result and result.message.tool_calls:
+            # 工具执行结果记为 tool 角色的一条记录
+            first_tool_call = result.message.tool_calls[0]
+            round_records.append(
+                cls._build_tool_record(tool_result, first_tool_call.id)
+            )
+
+            # 带工具结果，再次调用模型
             result = await cls.get_zhipu_result(
                 uid,
                 ChatConfig.get("CHAT_MODEL"),
@@ -134,7 +283,21 @@ class ChatManager:
                 session,
                 use_tool=False,
             )
-            await cls.add_anytype_message(uid, result.message)  # type: ignore
+
+            # 这里也只在返回结构正常时才追加到 round_records
+            if result.error_code != 0 or result.message is None:
+                logger.error(
+                    f"工具链第二次调用模型失败: {result.content}",
+                    "zhipu_toolkit",
+                    session=session,
+                )
+                return f"出错了: {result.content}"
+
+            round_records.append(cls._build_assistant_record(result.message))
+
+        # 到这里，整轮对话都是“结构正常”的，可以一次性写入 DB + 缓存
+        await cls._flush_round_history(uid, round_records)
+
         answer = extract_message_content(result.content)
         logger.info(
             f"USERNAME `{username}` 问题：{message} ---- 回答：{answer}",
@@ -144,56 +307,41 @@ class ChatManager:
         return answer
 
     @classmethod
-    async def add_user_message(
-        cls, content: str, uid: str, res_url: str | None = None
-    ) -> None:
-        await ZhipuChatHistory.create(
-            uid=uid,
-            role="user",
-            content=content,
-            res_url=res_url,
-        )
-
-    @classmethod
-    async def add_anytype_message(cls, uid: str, message: CompletionMessage) -> None:
-        tool_calls_serialized = (
-            [call.model_dump() for call in message.tool_calls]
-            if message.tool_calls
-            else None
-        )
-        await ZhipuChatHistory.create(
-            uid=uid,
-            role=message.role,
-            content=message.content,
-            tool_calls=tool_calls_serialized,
-            tool_call_id=getattr(message, "tool_call_id", None),
-        )
-
-    @classmethod
-    async def add_tool_call_message(cls, uid: str, content: str, tool_id: str) -> None:
-        await ZhipuChatHistory.create(
-            uid=uid,
-            role="tool",
-            tool_call_id=tool_id,
-            content=content,
-        )
-
-    @classmethod
-    async def add_system_message(cls, uid: str) -> None:
-        if not await ZhipuChatHistory.filter(uid=uid, role="system").exists():
-            soul = await get_prompt()
-            await ZhipuChatHistory.create(
-                uid=uid, role="system", content=soul, platform="system"
-            )
-
-    @classmethod
     async def clear_history(cls, uid: str | None = None) -> int:
+        """清理历史记录，并同步清空内存缓存。"""
+        if uid is None:
+            _CHAT_HISTORY_CACHE.clear()
+        else:
+            _CHAT_HISTORY_CACHE.pop(uid, None)
         return await ZhipuChatHistory.clear_history(uid)
 
     @classmethod
     async def get_chat_history(cls, uid: str) -> list[dict]:
-        """统一获取对话历史的入口"""
-        return await ZhipuChatHistory.get_history(uid)
+        """统一获取对话历史的入口，带内存缓存 + TTL。
+
+        行为:
+            - 若缓存中存在并且在 TTL 内，则直接返回缓存中的历史；
+            - 否则从数据库加载最近若干条记录，写入缓存并返回。
+        """
+        now = datetime.datetime.now()
+        if cache_info := _CHAT_HISTORY_CACHE.get(uid):
+            last_access: datetime.datetime = cache_info.get("last_access", now)
+            if (now - last_access).total_seconds() <= CHAT_HISTORY_TTL_SECONDS:
+                # 缓存有效，更新访问时间并返回
+                cache_info["last_access"] = now
+                data: list = cache_info.get("data", [])
+                data.insert(0, {"role": "system", "content": await get_prompt()})
+                return data
+
+        # 缓存不存在或已过期，从数据库获取完整历史
+        history = await ZhipuChatHistory.get_history(uid)
+        # 写入缓存，截断长度避免无限增长
+        _CHAT_HISTORY_CACHE[uid] = {
+            "last_access": now,
+            "data": history[-CHAT_HISTORY_MAX_LEN:],
+        }
+        history.insert(0, {"role": "system", "content": await get_prompt()})
+        return history
 
     @classmethod
     async def call_impersonation_ai(cls, session: Uninfo):
@@ -360,11 +508,9 @@ class ChatManager:
                     "zhipu_toolkit",
                     session=session,
                 )
-                result = await ToolsManager.call_func(
+                return await ToolsManager.call_func(
                     session, tool_call.function.name, args
                 )
-                await cls.add_tool_call_message(uid, result, tool_call.id)
-                return result
             except Exception as e:
                 logger.error(
                     f"UID {uid} 工具调用失败",

--- a/zhipu_toolkit/model.py
+++ b/zhipu_toolkit/model.py
@@ -101,12 +101,6 @@ class ZhipuChatHistory(Model):
         )
         return data
 
-    @classmethod
-    async def update_system_content(cls, content: str, uid: str | None = None) -> int:
-        query = cls.filter(role="system")
-        if uid:
-            query = query.filter(uid=uid)
-        return await query.update(content=content)
 
     @classmethod
     async def get_user_list(cls) -> list[tuple[str, int]]:


### PR DESCRIPTION
- 引入 nonebot_plugin_apscheduler 实现定时任务
- 实现 PROMPT 文件定时同步机制，每30分钟检查一次文件变化
- 添加 normal_chat 历史记录内存缓存，减少数据库频繁访问
- 实现缓存清理机制，避免内存无限增长
- 重构对话历史管理逻辑，支持批量写入和缓存同步
- 优化工具调用流程，修复历史记录存储问题
- 删除废弃的 update_system_content 方法

## Summary by Sourcery

为普通聊天记录添加内存缓存和定时维护机制，并基于 PROMPT 文件变更引入定时的提示词同步机制。

New Features:
- 为 `normal_chat` 历史记录引入带 TTL 和大小限制的内存缓存，以减少数据库读取。
- 添加定时任务，周期性清理过期的聊天历史缓存条目，并在磁盘上的 PROMPT 文件发生变更时进行同步。

Bug Fixes:
- 修复在发生工具调用或模型错误时，聊天历史记录条目可能被不一致存储的问题。

Enhancements:
- 重构 `normal_chat` 对话处理逻辑，将完整的一轮对话先进行缓冲，并在一个批次中同时持久化到数据库和缓存。
- 优化工具调用的对话流程，确保工具调用消息和后续助手消息能作为一段连贯的历史记录被正确持久化。
- 改进提示词加载逻辑，使用全局内存中的 PROMPT，并采用更安全的重载逻辑和惰性初始化，避免不必要的文件 I/O。

Chores:
- 从聊天历史模型中移除未使用的 `update_system_content` 方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add in-memory caching and scheduled maintenance for normal chat history, and introduce a scheduled prompt sync mechanism based on PROMPT file changes.

New Features:
- Introduce an in-memory cache for normal_chat history with TTL and size limits to reduce database reads.
- Add scheduled jobs to periodically prune stale chat history cache entries and sync the PROMPT file when it changes on disk.

Bug Fixes:
- Fix issues where chat history entries could be inconsistently stored when tool calls or model errors occurred.

Enhancements:
- Refactor normal_chat dialogue handling to buffer a full conversation round and persist it to the database and cache in a single batch.
- Optimize tool-calling conversation flow to correctly persist tool call and follow-up assistant messages in a single coherent history.
- Improve prompt loading to use a global in-memory PROMPT with safer reload logic and lazy initialization, avoiding unnecessary file I/O.

Chores:
- Remove the unused update_system_content method from the chat history model.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为普通聊天记录添加内存缓存和定时维护机制，并基于 PROMPT 文件变更引入定时的提示词同步机制。

New Features:
- 为 `normal_chat` 历史记录引入带 TTL 和大小限制的内存缓存，以减少数据库读取。
- 添加定时任务，周期性清理过期的聊天历史缓存条目，并在磁盘上的 PROMPT 文件发生变更时进行同步。

Bug Fixes:
- 修复在发生工具调用或模型错误时，聊天历史记录条目可能被不一致存储的问题。

Enhancements:
- 重构 `normal_chat` 对话处理逻辑，将完整的一轮对话先进行缓冲，并在一个批次中同时持久化到数据库和缓存。
- 优化工具调用的对话流程，确保工具调用消息和后续助手消息能作为一段连贯的历史记录被正确持久化。
- 改进提示词加载逻辑，使用全局内存中的 PROMPT，并采用更安全的重载逻辑和惰性初始化，避免不必要的文件 I/O。

Chores:
- 从聊天历史模型中移除未使用的 `update_system_content` 方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add in-memory caching and scheduled maintenance for normal chat history, and introduce a scheduled prompt sync mechanism based on PROMPT file changes.

New Features:
- Introduce an in-memory cache for normal_chat history with TTL and size limits to reduce database reads.
- Add scheduled jobs to periodically prune stale chat history cache entries and sync the PROMPT file when it changes on disk.

Bug Fixes:
- Fix issues where chat history entries could be inconsistently stored when tool calls or model errors occurred.

Enhancements:
- Refactor normal_chat dialogue handling to buffer a full conversation round and persist it to the database and cache in a single batch.
- Optimize tool-calling conversation flow to correctly persist tool call and follow-up assistant messages in a single coherent history.
- Improve prompt loading to use a global in-memory PROMPT with safer reload logic and lazy initialization, avoiding unnecessary file I/O.

Chores:
- Remove the unused update_system_content method from the chat history model.

</details>

</details>