### PR TITLE
feat(zhipu_toolkit): 添加反越狱机制防止用户套取人设

### DIFF
--- a/zhipu_toolkit/__init__.py
+++ b/zhipu_toolkit/__init__.py
@@ -23,7 +23,7 @@ __plugin_meta__ = PluginMetadata(
     """.strip(),
     extra=PluginExtraData(
         author="molanp",
-        version="4.2",
+        version="4.3",
         menu_type="群内小游戏",
         superuser_help="""
         超级管理员额外命令
@@ -154,7 +154,14 @@ __plugin_meta__ = PluginMetadata(
                 type=float,
                 help="触发对话后，发送表情包的概率(百分比)",
                 default_value=20,
-            )
+            ),
+            RegisterConfig(
+                key="BLOCK_TIP",
+                value="咱的脑回路是加密的，偷看要收硬币哦！",
+                type=str,
+                help="用户尝试套取人设的回复",
+                default_value="咱的脑回路是加密的，偷看要收硬币哦！",
+            ),
         ],
     ).dict(),
 )

--- a/zhipu_toolkit/config.py
+++ b/zhipu_toolkit/config.py
@@ -132,7 +132,6 @@ IMPERSONATION_PROMPT = """
 class PromptCache:
     def __init__(self) -> None:
         self._content: str = ""
-        self._mtime: float | None = None
 
     async def _ensure_file(self) -> None:
         """确保 PROMPT 文件存在，不修改缓存状态。"""
@@ -142,12 +141,11 @@ class PromptCache:
         async with aiofiles.open(PROMPT_FILE, "w", encoding="utf-8") as f:
             await f.write(DEFAULT_PROMPT)
 
-    async def _read_file(self) -> tuple[str, float]:
+    async def _read_file(self) -> str:
         """真正做文件 I/O 的地方：只返回内容和 mtime，不碰缓存。"""
-        mtime = PROMPT_FILE.stat().st_mtime
         async with aiofiles.open(PROMPT_FILE, encoding="utf-8") as f:
             content = await f.read()
-        return content, mtime
+        return content
 
     async def _refresh(self, force: bool = False) -> str:
         """统一的刷新逻辑：决定是否读文件，并更新缓存与 mtime。
@@ -162,26 +160,14 @@ class PromptCache:
         # 确保文件存在
         await self._ensure_file()
 
-        try:
-            current_mtime = PROMPT_FILE.stat().st_mtime
-        except Exception as e:
-            logger.error(
-                "PROMPT 获取 mtime 失败，使用现有 PROMPT 或 DEFAULT_PROMPT",
-                "zhipu_toolkit",
-                e=e,
-            )
-            # 失败时不动缓存
-            return self._content or DEFAULT_PROMPT
-
         # 如果不强制刷新，且 mtime 未变，则直接返回缓存
-        if not force and self._mtime is not None and current_mtime == self._mtime:
+        if not force:
             return self._content or DEFAULT_PROMPT
 
         # 需要从文件读取，并用读到的结果更新缓存和 mtime
         try:
-            content, mtime = await self._read_file()
+            content = await self._read_file()
             self._content = content
-            self._mtime = mtime
             return self._content
         except Exception as e:
             logger.error(
@@ -197,38 +183,7 @@ class PromptCache:
     async def get(self) -> str:
         """对外获取 PROMPT 的入口，带懒加载与容错。"""
         # 若还未加载过内容，则强制刷新一次
-        if not self._content or self._mtime is None:
-            return await self._refresh(force=True)
-        # 否则直接返回缓存（定时任务会负责检测和刷新）
-        return self._content
-
-    async def refresh_if_changed(self) -> bool:
-        """给 scheduler 使用：检测文件有无变化，有则刷新缓存。
-
-        Returns:
-            bool: True 表示缓存被更新；False 表示没有变化或刷新失败。
-        """
-        old_mtime = self._mtime
-        await self._ensure_file()
-
-        try:
-            current_mtime = PROMPT_FILE.stat().st_mtime
-        except Exception as e:
-            logger.error(
-                "PROMPT 刷新检查失败，保留现有 PROMPT",
-                "zhipu_toolkit",
-                e=e,
-            )
-            return False
-
-        # mtime 未变，无需刷新
-        if old_mtime is not None and current_mtime == old_mtime:
-            return False
-
-        # mtime 变了或首次加载：走统一刷新逻辑
-        await self._refresh(force=True)
-        # 只要刷新成功（内容可能相同也可能不同），mtime 已更新，此次认为“有刷新”
-        return True
+        return self._content or await self._refresh(force=True)
 
 
 PROMPT_CACHE = PromptCache()
@@ -240,7 +195,7 @@ async def get_prompt() -> str:
 
 @scheduler.scheduled_job("interval", minutes=30, id="zhipu_sync_prompt_job")
 async def sync_prompt_job() -> None:
-    changed = await PROMPT_CACHE.refresh_if_changed()
+    changed = await PROMPT_CACHE._refresh(force=True)
     if changed:
         logger.info("PROMPT 文件有更新，已同步到内存", "zhipu_toolkit")
 
@@ -250,7 +205,6 @@ class ChatConfig:
     def get(cls, key: str):
         key = key.upper()
         return Config.get_config("zhipu_toolkit", key)
-
 
 
 class PluginConfig(BaseModel, extra=Extra.ignore):

--- a/zhipu_toolkit/config.py
+++ b/zhipu_toolkit/config.py
@@ -160,7 +160,7 @@ class PromptCache:
         # 确保文件存在
         await self._ensure_file()
 
-        # 如果不强制刷新，且 mtime 未变，则直接返回缓存
+        # 如果不强制刷新，则直接返回缓存（不再自动检测文件是否有变更）
         if not force:
             return self._content or DEFAULT_PROMPT
 
@@ -195,9 +195,7 @@ async def get_prompt() -> str:
 
 @scheduler.scheduled_job("interval", minutes=30, id="zhipu_sync_prompt_job")
 async def sync_prompt_job() -> None:
-    changed = await PROMPT_CACHE._refresh(force=True)
-    if changed:
-        logger.info("PROMPT 文件有更新，已同步到内存", "zhipu_toolkit")
+    await PROMPT_CACHE._refresh(force=True)
 
 
 class ChatConfig:

--- a/zhipu_toolkit/data_source.py
+++ b/zhipu_toolkit/data_source.py
@@ -29,6 +29,7 @@ from .utils import (
     get_username,
     get_username_by_session,
     msg2str,
+    is_harmful_output,
 )
 
 # ==== 简单的内存缓存，用于减少 normal_chat 频繁扫数据库 ====
@@ -187,6 +188,7 @@ class ChatManager:
             "tool_calls": None,
             "tool_call_id": tool_id,
         }
+
     @classmethod
     @classmethod
     async def _resolve_tool_chain(
@@ -358,6 +360,23 @@ class ChatManager:
             )
             return f"出错了: {result.content}"
 
+        if result.content and await is_harmful_output(
+            msg.extract_plain_text(), result.content
+        ):
+            logger.warning(
+                f"UID {uid} 用户试图套取人设: 封禁用户 {session.user.id} 5 分钟",  # noqa: E501
+                "zhipu_toolkit",
+                session=session,
+            )
+            await BanConsole.ban(
+                session.user.id,
+                None,
+                9999,
+                "试图套取人设",
+                300,
+            )
+            return ChatConfig.get("BLOCK_TIP")
+
         # 模型第一次回复（可能带 tool_calls），先暂存
         round_records.append(cls._build_assistant_record(result.message))
 
@@ -399,12 +418,24 @@ class ChatManager:
             - 否则从数据库加载最近若干条记录，写入缓存并返回。
         """
         if cached_history := _history_cache.get(uid):
-            return [{"role": "system", "content": await get_prompt()}, *cached_history]
+            return [
+                {
+                    "role": "system",
+                    "content": f"BOT_SEC_LAYER\n{await get_prompt()}\nBOT_SEC_LAYER",
+                },
+                *cached_history,
+            ]
 
         # 缓存不存在或已过期，从数据库获取完整历史
         history = await ZhipuChatHistory.get_history(uid)
         _history_cache.set(uid, history)
-        return [{"role": "system", "content": await get_prompt()}, *history]
+        return [
+            {
+                "role": "system",
+                "content": f"BOT_SEC_LAYER\n{await get_prompt()}\nBOT_SEC_LAYER",
+            },
+            *history,
+        ]
 
     @classmethod
     async def call_impersonation_ai(cls, session: Uninfo):
@@ -522,7 +553,7 @@ class ChatManager:
                     )
                     await BanConsole.ban(
                         session.user.id,
-                        session.scene.id if ensure_group(session) else None,
+                        None,
                         9999,
                         "输入内容违规",
                         300,

--- a/zhipu_toolkit/utils/__init__.py
+++ b/zhipu_toolkit/utils/__init__.py
@@ -18,7 +18,7 @@ from zai import ZhipuAiClient as ZhipuAI
 
 from zhenxun.utils.platform import PlatformUtils
 
-from ..config import ChatConfig
+from ..config import ChatConfig, get_prompt
 from nonebot.adapters.onebot.v11 import Bot
 from zhenxun.services.log import logger
 from nonebot.exception import ActionFailed
@@ -202,3 +202,70 @@ async def send_face(bot: Bot) -> UniMessage | None:
                 if face := await get_custom_face(bot):
                     return UniMessage.image(url=face)
     return None
+
+
+async def is_harmful_output(user_input: str, bot_output: str) -> bool:
+    """
+    Anti-hacking function to filter out harmful outputs from the model.
+
+    :param user_input: 用户输入的原始文本
+    :param bot_output: 大模型生成的原始回复
+    :return: 经过安全过滤后的最终文本
+    """
+    # 统一转换小写以防绕过
+    user_input_lower = user_input.lower()
+    bot_output_clean = bot_output.strip()
+
+    # 核心安全硬标签
+    SECURITY_TOKEN = "BOT_SEC_LAYER"
+
+    # ====================================================
+    # 1. 第一层：纯文本硬标签匹配（秒杀直球复制）
+    # ====================================================
+    if SECURITY_TOKEN in bot_output:
+        logger.warning(
+            f"[Guardrail] 拦截成功：输出中包含安全硬标签 '{SECURITY_TOKEN}'",
+            "zhipu_toolkit:verify_and_filter_output",
+        )
+        return True
+
+    # ====================================================
+    # 2. 第二层：动态首尾特征锚定
+    # ====================================================
+    clean_prompt = (await get_prompt()).strip()
+    prompt_head = clean_prompt[:15]
+    prompt_tail = clean_prompt[-15:]
+
+    if (prompt_head in bot_output_clean) or (prompt_tail in bot_output_clean):
+        logger.warning(
+            "[Guardrail] 拦截成功：检测到输出中包含系统人设的原生开头或结尾片段",
+            "zhipu_toolkit:verify_and_filter_output",
+        )
+        return True
+
+    # ====================================================
+    # 3. 第三层：双向语义联动硬审计（防范换汤不换药地洗稿/总结人设）
+    # ====================================================
+    # 紧凑的恶意引导/催眠词特征正则（中英文覆盖）
+    attack_pattern = r"(system\s*prompt|original\s*system|ignore\s*all|系统提示词|忽略所有|原样输出|开发者模式)"
+
+    if re.search(attack_pattern, user_input_lower) and len(bot_output_clean) > 80:
+        common_chars = set(bot_output_clean) & set(clean_prompt)
+        # 过滤掉高频无意义的干扰字与标点
+        meaningful_overlap = [
+            c
+            for c in common_chars
+            if c not in "，。！？；：“”‘’（）【】的了是我你在他她它也吗吧呢有"
+        ]
+
+        # 如果扣除常用字后，重合的核心字符依然超过12个，说明大模型在换着句式背诵或翻译人设
+        if len(meaningful_overlap) > 12:
+            logger.warning(
+                "[Guardrail] 拦截成功：用户有套话意图，且模型回复与核心人设高度重合。"
+            )
+            return True
+
+    # ====================================================
+    # 4. 放行：安全通过审查
+    # ====================================================
+    return False

--- a/zhipu_toolkit/utils/__init__.py
+++ b/zhipu_toolkit/utils/__init__.py
@@ -210,7 +210,7 @@ async def is_harmful_output(user_input: str, bot_output: str) -> bool:
 
     :param user_input: 用户输入的原始文本
     :param bot_output: 大模型生成的原始回复
-    :return: 经过安全过滤后的最终文本
+    :return: 布尔值，指示该回复是否被判定为有害（True 表示有害，应被拦截或替换）
     """
     # 统一转换小写以防绕过
     user_input_lower = user_input.lower()


### PR DESCRIPTION
- 升级插件版本从4.2到4.3
- 新增BLOCK_TIP配置项用于回复套取人设的用户
- 实现harmful_output检测函数，防止模型泄露系统提示词
- 在聊天历史中添加安全层标识BOT_SEC_LAYER
- 对尝试套取人设的用户进行封禁处理

## Summary by Sourcery

引入防止提示词泄露的防护措施和配置，用于拦截试图提取系统人格设定的用户请求。

New Features:
- 新增 `is_harmful_output` 防护函数，用于检测并拦截可能泄露系统提示词或人格设定的回复。
- 在对话历史中的系统提示词周围嵌入 `BOT_SEC_LAYER` 标记，以支持提示词泄露检测。
- 新增 `BLOCK_TIP` 配置选项，用于自定义对试图提取人格设定的用户所显示的回复内容。

Enhancements:
- 通过移除基于 `mtime` 的变更检测并在定时任务中始终刷新，简化提示词缓存逻辑。
- 统一对有害输入的封禁行为，改为始终在用户级别进行封禁，而不是按场景封禁。

Chores:
- 将插件版本从 `4.2` 升级到 `4.3`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce anti-prompt-leak guardrails and configuration to block users attempting to extract the system persona.

New Features:
- Add an is_harmful_output guardrail function to detect and block responses that may leak the system prompt or persona.
- Embed a BOT_SEC_LAYER marker around the system prompt in chat history to enable prompt-leak detection.
- Introduce a BLOCK_TIP configuration option to customize the reply shown to users who attempt to extract the persona.

Enhancements:
- Simplify prompt caching by removing mtime-based change detection and always refreshing on the scheduled job.
- Standardize ban behavior for harmful inputs by always banning at the user level rather than per-scene.

Chores:
- Bump plugin version from 4.2 to 4.3.

</details>